### PR TITLE
Arm mitigation

### DIFF
--- a/docs/UserControls.md
+++ b/docs/UserControls.md
@@ -6,7 +6,7 @@
 | Release             | RIGHT BUMPER        |
 |                     |                     |
 | Arm Calibrate       | BACK                |
-| Arm Zero when home  | A                   |
+| Arm Zero when home  | B                   |
 |                     |                     |
 | Arm Home            | X                   |
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -27,6 +27,7 @@ import frc.lib.io.vision.VisionIOAprilTag;
 import frc.lib.leds.LEDManager;
 import frc.lib.utils.AllianceFlipUtil;
 import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.arm.ArmFloorCMD;
 import frc.robot.commands.arm.ArmHomeCMD;
 import frc.robot.commands.arm.ArmManualDownCMD;
@@ -313,6 +314,7 @@ public class RobotContainer {
 
     // Need to set to use automated movements, should be set in Autonomous init.
     driverController.back().onTrue(new ArmCalibrateCMD(arm, led2023));
+    driverController.a().onTrue(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
 
     // Manual arm movements
     operatorController.leftStick().onTrue(new ArmStopCMD(arm, led2023));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -314,7 +314,7 @@ public class RobotContainer {
 
     // Need to set to use automated movements, should be set in Autonomous init.
     driverController.back().onTrue(new ArmCalibrateCMD(arm, led2023));
-    driverController.a().onTrue(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
+    driverController.b().onTrue(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
 
     // Manual arm movements
     operatorController.leftStick().onTrue(new ArmStopCMD(arm, led2023));

--- a/src/main/java/frc/robot/commands/arm/ArmCalibrateZeroAtHomeCMD.java
+++ b/src/main/java/frc/robot/commands/arm/ArmCalibrateZeroAtHomeCMD.java
@@ -1,0 +1,36 @@
+package frc.robot.commands.arm;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.arm.Arm;
+import frc.robot.subsystems.led.Led2023;
+
+public class ArmCalibrateZeroAtHomeCMD extends CommandBase {
+  private final Arm arm;
+  private final Led2023 ledStrip;
+
+  public ArmCalibrateZeroAtHomeCMD(Arm arm, Led2023 ledStrip) {
+    this.arm = arm;
+    this.ledStrip = ledStrip;
+
+    addRequirements(arm, ledStrip);
+  }
+
+  @Override
+  public void initialize() {
+    if (!arm.isCalibrated()) {
+      arm.setCalibratedAssumeHomePosition();
+    }
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    if (arm.isCalibrated()) {
+      ledStrip.setArmCalibrated();
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/auto/ScoreConeHigh.java
+++ b/src/main/java/frc/robot/commands/auto/ScoreConeHigh.java
@@ -4,7 +4,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.arm.ArmScoreHighNodeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.commands.intakerelease.WantConeCMD;
@@ -19,7 +19,7 @@ public class ScoreConeHigh extends SequentialCommandGroup {
   public ScoreConeHigh(
       Drive drive, Arm arm, IntakeRelease intakeRelease, Led2023 ledStrip, int aprilTag) {
     addCommands(
-        new ArmCalibrateCMD(arm, ledStrip),
+        new ArmCalibrateZeroAtHomeCMD(arm, ledStrip),
         new WantConeCMD(intakeRelease, ledStrip),
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/ScoreConeLow.java
+++ b/src/main/java/frc/robot/commands/auto/ScoreConeLow.java
@@ -4,7 +4,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.arm.ArmScoreLowNodeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
@@ -16,7 +16,7 @@ import java.util.List;
 public class ScoreConeLow extends SequentialCommandGroup {
   public ScoreConeLow(Drive drive, Arm arm, IntakeRelease intakeRelease, Led2023 led2023) {
     addCommands(
-        new ArmCalibrateCMD(arm, led2023),
+        new ArmCalibrateZeroAtHomeCMD(arm, led2023),
         new GoToTrajectory(
             drive,
             List.of(

--- a/src/main/java/frc/robot/commands/auto/ScoreConeMid.java
+++ b/src/main/java/frc/robot/commands/auto/ScoreConeMid.java
@@ -4,7 +4,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.arm.ArmScoreMidNodeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.commands.intakerelease.WantConeCMD;
@@ -17,7 +17,7 @@ import java.util.List;
 public class ScoreConeMid extends SequentialCommandGroup {
   public ScoreConeMid(Drive drive, Arm arm, IntakeRelease intakeRelease, Led2023 ledStrip) {
     addCommands(
-        new ArmCalibrateCMD(arm, ledStrip),
+        new ArmCalibrateZeroAtHomeCMD(arm, ledStrip),
         new WantConeCMD(intakeRelease, ledStrip),
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/ScoreThenMoveOut8.java
+++ b/src/main/java/frc/robot/commands/auto/ScoreThenMoveOut8.java
@@ -4,7 +4,7 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.arm.ArmScoreHighNodeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.commands.intakerelease.ReleaseCMD;
@@ -18,7 +18,7 @@ import java.util.List;
 public class ScoreThenMoveOut8 extends SequentialCommandGroup {
   public ScoreThenMoveOut8(Drive drive, Arm arm, IntakeRelease intakeRelease, Led2023 ledStrip) {
     addCommands(
-        new ArmCalibrateCMD(arm, ledStrip),
+        new ArmCalibrateZeroAtHomeCMD(arm, ledStrip),
         new WantCubeCMD(intakeRelease, ledStrip),
         new ArmScoreHighNodeCMD(arm, intakeRelease, ledStrip),
         new GoToTrajectory(

--- a/src/main/java/frc/robot/commands/auto/better/Leave.java
+++ b/src/main/java/frc/robot/commands/auto/better/Leave.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class Leave extends SequentialCommandGroup {
   public Leave(Drive drive, Arm arm, Led2023 led2023) {
-    addCommands(new ArmCalibrateCMD(arm, led2023));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
     addCommands(
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/better/LeaveStraight6.java
+++ b/src/main/java/frc/robot/commands/auto/better/LeaveStraight6.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class LeaveStraight6 extends SequentialCommandGroup {
   public LeaveStraight6(Drive drive, Arm arm, Led2023 led2023) {
-    addCommands(new ArmCalibrateCMD(arm, led2023));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
     addCommands(
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/better/LeaveStraight6Balance.java
+++ b/src/main/java/frc/robot/commands/auto/better/LeaveStraight6Balance.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class LeaveStraight6Balance extends SequentialCommandGroup {
   public LeaveStraight6Balance(Drive drive, Arm arm, Led2023 led2023) {
-    addCommands(new ArmCalibrateCMD(arm, led2023));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
     addCommands(
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/better/LeaveStraight8.java
+++ b/src/main/java/frc/robot/commands/auto/better/LeaveStraight8.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class LeaveStraight8 extends SequentialCommandGroup {
   public LeaveStraight8(Drive drive, Arm arm, Led2023 led2023) {
-    addCommands(new ArmCalibrateCMD(arm, led2023));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
     addCommands(
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/better/LeaveStraight8Balance.java
+++ b/src/main/java/frc/robot/commands/auto/better/LeaveStraight8Balance.java
@@ -9,7 +9,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -44,7 +44,7 @@ public class LeaveStraight8Balance extends SequentialCommandGroup {
             position0.getY(),
             position0.getRotation());
 
-    addCommands(new ArmCalibrateCMD(arm, led2023));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
     addCommands(
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/commands/auto/better/ScoreOne.java
+++ b/src/main/java/frc/robot/commands/auto/better/ScoreOne.java
@@ -1,7 +1,7 @@
 package frc.robot.commands.auto.better;
 
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.auto.ScoreConeHigh;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -10,7 +10,7 @@ import frc.robot.subsystems.led.Led2023;
 
 public class ScoreOne extends SequentialCommandGroup {
   public ScoreOne(Drive drive, Arm arm, IntakeRelease intakeRelease, Led2023 ledStrip) {
-    addCommands(new ArmCalibrateCMD(arm, ledStrip));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, ledStrip));
     addCommands(new ScoreConeHigh(drive, arm, intakeRelease, ledStrip, 6));
   }
 }

--- a/src/main/java/frc/robot/commands/auto/better/ScoreOneLeave.java
+++ b/src/main/java/frc/robot/commands/auto/better/ScoreOneLeave.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.auto.ScoreConeHigh;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class ScoreOneLeave extends SequentialCommandGroup {
   public ScoreOneLeave(Drive drive, Arm arm, IntakeRelease intakeRelease, Led2023 ledStrip) {
-    addCommands(new ArmCalibrateCMD(arm, ledStrip));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, ledStrip));
     addCommands(new ScoreConeHigh(drive, arm, intakeRelease, ledStrip, 7));
     addCommands(
         new GoToTrajectory(

--- a/src/main/java/frc/robot/commands/auto/better/ScoreOneLeaveBalance.java
+++ b/src/main/java/frc/robot/commands/auto/better/ScoreOneLeaveBalance.java
@@ -47,7 +47,7 @@ public class ScoreOneLeaveBalance extends SequentialCommandGroup {
             position0.getY(),
             position0.getRotation());
 
-    //    addCommands(new ArmCalibrateCMD(arm));
+    //    addCommands(new ArmCalibrateZeroAtHomeCMD(arm));
     //    addCommands(new ScoreConeHigh(drive, arm, intakeRelease, ledStrip, 6));
 
     addCommands(

--- a/src/main/java/frc/robot/commands/auto/better/StraightBack.java
+++ b/src/main/java/frc/robot/commands/auto/better/StraightBack.java
@@ -8,7 +8,7 @@ import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.lib.holonomictrajectory.Waypoint;
 import frc.robot.FieldConstants;
 import frc.robot.FieldConstants.Community;
-import frc.robot.commands.arm.ArmCalibrateCMD;
+import frc.robot.commands.arm.ArmCalibrateZeroAtHomeCMD;
 import frc.robot.commands.drive.GoToTrajectory;
 import frc.robot.subsystems.arm.Arm;
 import frc.robot.subsystems.drive.Drive;
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class StraightBack extends SequentialCommandGroup {
   public StraightBack(Drive drive, Arm arm, Led2023 led2023) {
-    addCommands(new ArmCalibrateCMD(arm, led2023));
+    addCommands(new ArmCalibrateZeroAtHomeCMD(arm, led2023));
     addCommands(
         new GoToTrajectory(
             drive,

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -127,6 +127,14 @@ public class Arm extends SubsystemBase {
     calibrateRotateOrigin = armIOInputs.rotatePosition;
   }
 
+  /** Zeros the positions of both motors, assuming that we're already at HOME position. */
+  public void setCalibratedAssumeHomePosition() {
+    armIO.resetExtendEncoderPosition();
+    armIO.resetRotateEncoderPosition();
+    isCalibrated = true;
+    hold();
+  }
+
   public void hold() {
     hold(armIOInputs.extendPosition);
   }

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -54,6 +54,8 @@ public class Arm extends SubsystemBase {
   private double calibrateRotateOrigin = 0;
   private boolean isDropping = false;
 
+  private Timer autoRetractTimer = new Timer();
+
   private static final double EXTEND_TOLERANCE_METERS = 0.008;
   private static final double ROTATE_TOLERANCE_METERS = 0.008;
 
@@ -265,7 +267,8 @@ public class Arm extends SubsystemBase {
     logger.recordOutput("Arm/AutoMode", autoMode.toString());
     switch (autoMode) {
       case RETRACT:
-        if (armIOInputs.extendPosition < SAFE_RETRACT_NON_HOME + EXTEND_TOLERANCE_METERS) {
+        if (autoRetractTimer.hasElapsed(1)
+            || armIOInputs.extendPosition < SAFE_RETRACT_NON_HOME + EXTEND_TOLERANCE_METERS) {
           setExtendVoltage(0);
           autoMode = rotateSetpoint > 0 ? AutoMode.ROTATE : AutoMode.RETRACT_FULL;
         } else {
@@ -274,8 +277,9 @@ public class Arm extends SubsystemBase {
         break;
 
       case RETRACT_FULL:
-        if (armIOInputs.extendPosition
-            < RobotConstants.get().armExtendMinMeters() + EXTEND_TOLERANCE_METERS) {
+        if (autoRetractTimer.hasElapsed(1.5)
+            || armIOInputs.extendPosition
+                < RobotConstants.get().armExtendMinMeters() + EXTEND_TOLERANCE_METERS) {
           setExtendVoltage(0);
           autoMode = AutoMode.ROTATE;
         } else {
@@ -359,6 +363,8 @@ public class Arm extends SubsystemBase {
   public void setTargetPositions(double extendSetpoint, double rotateSetpoint) {
     mode = ArmMode.AUTO;
     autoMode = AutoMode.RETRACT;
+    autoRetractTimer.reset();
+    autoRetractTimer.start();
     this.extendSetpoint =
         MathUtil.clamp(
             extendSetpoint,


### PR DESCRIPTION
- Create an alternate way to calibrate when we know we're already at the home position
- Add a timeout to retracting the arm in auto mode - this will allow us to reach set points if the motor is not strong enough to pull the arm in.