### PR TITLE
Document operator panel button mapping to RPi pico GPs

### DIFF
--- a/Operator_Controls_Map_README.md
+++ b/Operator_Controls_Map_README.md
@@ -1,0 +1,20 @@
+| RPi Pico Pin | GP2040-CE | Button    | Used For              |
+| ------------ | --------- | ------    | --------------------- |
+| **MODE SWITCH** |
+| GP16         | S1        | BACK      | Want cube(T)/cone(F)) |
+| **MANUAL** |
+| GP2          | UP        | POV UP    | Arm manual up         |
+| GP3          | DOWN      | POV DOWN  | Arm manual down       |
+| GP4          | RIGHT     | POV RIGHT | Arm manual extend     |
+| GP5          | LEFT      | POV LEFT  | Arm manual retrack    |
+| **SCORE** |
+| GP6          | B1        | A         | Arm score low node    |
+| GP7          | B2        | B         | Arm score mid-node    |
+| GP11         | B4        | Y         | Arm score high node   |
+| **UTILITY** |
+| GP10         | B3        | X         | Arm home              |
+| GP18         | L3        | LS        | Arm stop              |
+| GP19         | R3        | RS        | Arm stop              |
+| **ACQUIRE** |
+| GP13         | L1        | LB        | Arm to shelf          |
+| GP12         | R1        | RB        | Arm floor             |


### PR DESCRIPTION
Provide a table showing the mapping between Raspberry Pi Pico GPIO pins, the GP2040-CE software, XBox controller buttons, and what we are using the button for