### PR TITLE
RobotState.getInstance() rather than setting it in constructor

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -35,7 +35,6 @@ import frc.robot.subsystems.intake.IntakeIO;
 import frc.robot.subsystems.led.Leds;
 import frc.robot.subsystems.pixy2.Pixy2;
 import frc.robot.subsystems.pixy2.Pixy2IO;
-import frc.robot.subsystems.robotstate.RobotState;
 import frc.robot.subsystems.shooter.Shooter;
 import frc.robot.subsystems.shooter.ShooterIO;
 import java.util.List;
@@ -130,7 +129,7 @@ public class RobotContainer {
       arm = new Arm(new ArmIO() {});
     }
     if (indexer == null) {
-      indexer = new Indexer(new IndexerIO() {}, new RobotState());
+      indexer = new Indexer(new IndexerIO() {});
     }
     if (shooter == null) {
       shooter = new Shooter(new ShooterIO() {});

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -8,14 +8,13 @@ import org.littletonrobotics.junction.Logger;
 
 public class Indexer extends SubsystemBase {
   private final IndexerIO io;
-  private final RobotState robotState;
+  private final RobotState robotState = RobotState.getInstance();
 
   private final IndexerIOInputsAutoLogged inputs = new IndexerIOInputsAutoLogged();
 
   /** Creates a new Indexer. */
-  public Indexer(IndexerIO io, RobotState robotState) {
+  public Indexer(IndexerIO io) {
     this.io = io;
-    this.robotState = robotState;
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
+import frc.robot.subsystems.robotstate.RobotState;
 import org.littletonrobotics.junction.Logger;
 
 public class Shooter extends SubsystemBase {
@@ -13,6 +14,7 @@ public class Shooter extends SubsystemBase {
   /** Creates a new shooter. */
   private final ShooterIO io;
 
+  private final RobotState robotState = RobotState.getInstance();
   private boolean PIDMode = false;
   private double currentVelocitySetpoint;
   private static final double SPEAKER_HEIGHT = 211.0;


### PR DESCRIPTION
changes RobotState to equal RobotState.getInstance() rather than setting it in the constructor